### PR TITLE
Make leader names clickable to edit

### DIFF
--- a/index.html
+++ b/index.html
@@ -167,7 +167,7 @@
       data.forEach(leader => {
         const row = document.createElement('tr')
         row.innerHTML = `
-          <td>${leader.full_name || ''}</td>
+          <td><a href="#" class="name-link">${leader.full_name || ''}</a></td>
           <td><a href="#" class="phone-link" data-phone="${leader.phone || ''}">${leader.phone || ''}</a></td>
           <td><a href="mailto:${leader.email || ''}">${leader.email || ''}</a></td>
           <td>${leader.status || ''}</td>
@@ -175,6 +175,15 @@
         `
 // Add Edit button click handler
 row.querySelector('.edit-btn').addEventListener('click', () => openEditForm(leader))
+
+// Make name clickable to open edit form
+const nameLink = row.querySelector('.name-link')
+if (nameLink) {
+  nameLink.addEventListener('click', (e) => {
+    e.preventDefault()
+    openEditForm(leader)
+  })
+}
 
 // Add Phone number interaction handler
 const phoneLink = row.querySelector('.phone-link')


### PR DESCRIPTION
## Summary
- link each leader name to open the edit form
- add listener so the name link acts the same as the Edit button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687e9c916028832889954f0f0236bea1