### PR TITLE
Improve comment management and admin menu

### DIFF
--- a/app/eslint.config.js
+++ b/app/eslint.config.js
@@ -5,7 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'tailwind.config.cjs']),
   {
     files: ['**/*.{js,jsx}'],
     extends: [


### PR DESCRIPTION
## Summary
- hide DB seeding actions in a dropdown menu
- allow toggling the add leader form
- show comments below each selected user
- support adding, editing and deleting comments
- ignore `tailwind.config.cjs` in ESLint

## Testing
- `npm run lint --prefix app`
- `npm run build --prefix app`


------
https://chatgpt.com/codex/tasks/task_e_687ea90383d88328b1d8ed5e5bccae77