### PR TITLE
Improve modal contrast

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,14 @@
     </div>
   </dialog>
   <style id="dark-mode-style">
+    :root {
+      --modal-bg-light: #ffffff;
+      --modal-text-light: #000000;
+      --modal-overlay-light: rgba(0,0,0,0.45);
+      --modal-bg-dark: #1c1c1e;
+      --modal-text-dark: #f5f5f7;
+      --modal-overlay-dark: rgba(0,0,0,0.8);
+    }
     body.dark-mode .profile-name {
       color: #e0e0e0 !important;
     }
@@ -178,10 +186,16 @@
     body.dark-mode select,
     body.dark-mode input,
     body.dark-mode input[type="date"] {
-      color: #f3f4f6 !important; /* Tailwind's gray-100 or any light color that contrasts well */
-      background: #232527 !important;
-      border-color: #333 !important;
+      color: var(--modal-text-dark) !important;
+      background: var(--modal-bg-dark) !important;
+      border-color: #555 !important;
       opacity: 1 !important;
+    }
+    body.dark-mode input:focus,
+    body.dark-mode select:focus,
+    body.dark-mode textarea:focus {
+      border-color: #0a84ff !important;
+      outline: 2px solid rgba(10,132,255,0.4) !important;
     }
     body.dark-mode .mobile-card-label,
     body.dark-mode .form-group label,
@@ -299,7 +313,7 @@
       color: #e0e0e0 !important;
     }
     body.dark-mode .modal-overlay {
-      background: rgba(24,26,27,0.85) !important;
+      background: var(--modal-overlay-dark) !important;
     }
     body.dark-mode .add-note-form,
     body.dark-mode .note-edit-form {
@@ -334,9 +348,9 @@
       color: #888 !important;
     }
     body.dark-mode .modal-content {
-      background: #232527 !important;
-      color: #e0e0e0 !important;
-      box-shadow: 0 4px 24px rgba(0,0,0,0.32) !important;
+      background: var(--modal-bg-dark) !important;
+      color: var(--modal-text-dark) !important;
+      box-shadow: 0 4px 32px rgba(0,0,0,0.4) !important;
       border: 1px solid #333 !important;
     }
     body.dark-mode .modal-header h3 {
@@ -431,10 +445,10 @@ body.dark-mode #filter-container option:checked {
     .modal-content {
       border-radius: 16px;
       box-shadow: 0 4px 24px rgba(0,0,0,0.12);
-      background: #fff;
+      background: var(--modal-bg-light);
+      color: var(--modal-text-light);
       padding: 2rem 1.5rem;
       font-size: 17px;
-      color: #222;
     }
     .modal-header h3 {
       font-size: 1.3rem;
@@ -501,9 +515,9 @@ body.dark-mode #filter-container option:checked {
       filter: brightness(1.08);
     }
     body.dark-mode .modal-content {
-      background: #232527 !important;
-      color: #e0e0e0 !important;
-      box-shadow: 0 4px 24px rgba(0,0,0,0.32) !important;
+      background: var(--modal-bg-dark) !important;
+      color: var(--modal-text-dark) !important;
+      box-shadow: 0 4px 32px rgba(0,0,0,0.4) !important;
     }
     body.dark-mode .modal-header h3 {
       color: #e0e0e0 !important;
@@ -663,11 +677,17 @@ input, button, select, textarea {
   padding: 1rem;
   font-size: 17px;
   line-height: 1.5;
-  border: 1px solid #ddd;
+  border: 1px solid #555;
   border-radius: 12px;
   width: 100%;
   min-height: 44px; /* Minimum tap target */
   box-sizing: border-box;
+  background: #fff;
+  color: #000;
+}
+input:focus, select:focus, textarea:focus {
+  border-color: #007aff;
+  outline: 2px solid rgba(0,122,255,0.4);
 }
     .hidden {
       display: none !important;
@@ -1120,29 +1140,30 @@ input, button, select, textarea {
     .note-text li {
       margin-bottom: 0.25rem;
     }
-    .modal-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0, 0, 0, 0.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-    }
-    .modal-content {
-      background: white;
-      padding: 1rem;
-      border-radius: 8px;
-      width: 95%;
-      max-width: 400px;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-      margin: 0.5rem;
-      max-height: 90vh;
-      overflow-y: auto;
-    }
+      .modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: var(--modal-overlay-light);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+      }
+      .modal-content {
+        background: var(--modal-bg-light);
+        color: var(--modal-text-light);
+        padding: 1rem;
+        border-radius: 16px;
+        width: 95%;
+        max-width: 400px;
+        box-shadow: 0 4px 32px rgba(0, 0, 0, 0.2);
+        margin: 0.5rem;
+        max-height: 90vh;
+        overflow-y: auto;
+      }
     
     @media (min-width: 768px) {
       .modal-content {
@@ -1201,12 +1222,14 @@ input, button, select, textarea {
       width: 100%;
       max-width: 100%;
       padding: 0.75rem;
-      border: 1px solid #ddd;
+      border: 1px solid #555;
       border-radius: 4px;
       font-size: 1rem;
       box-sizing: border-box;
       overflow: hidden;
       text-overflow: ellipsis;
+      background: #fff;
+      color: #000;
     }
     
     /* Specific styling for date inputs to prevent overflow */
@@ -1215,6 +1238,8 @@ input, button, select, textarea {
       padding: 0.6rem;
       -webkit-appearance: none;
       appearance: none;
+      background: #fff;
+      color: #000;
     }
     
     @media (max-width: 768px) {
@@ -1667,11 +1692,17 @@ input, button, select, textarea {
   padding: 1rem;
   font-size: 17px;
   line-height: 1.5;
-  border: 1px solid #ddd;
+  border: 1px solid #555;
   border-radius: 12px;
   width: 100%;
   min-height: 44px; /* Minimum tap target */
   box-sizing: border-box;
+  background: #fff;
+  color: #000;
+}
+input:focus, select:focus, textarea:focus {
+  border-color: #007aff;
+  outline: 2px solid rgba(0,122,255,0.4);
 }
     .hidden {
       display: none !important;
@@ -2107,29 +2138,30 @@ input, button, select, textarea {
     .note-text li {
       margin-bottom: 0.25rem;
     }
-    .modal-overlay {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      background: rgba(0, 0, 0, 0.5);
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      z-index: 1000;
-    }
-    .modal-content {
-      background: white;
-      padding: 1rem;
-      border-radius: 8px;
-      width: 95%;
-      max-width: 400px;
-      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-      margin: 0.5rem;
-      max-height: 90vh;
-      overflow-y: auto;
-    }
+      .modal-overlay {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: var(--modal-overlay-light);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 1000;
+      }
+      .modal-content {
+        background: var(--modal-bg-light);
+        color: var(--modal-text-light);
+        padding: 1rem;
+        border-radius: 16px;
+        width: 95%;
+        max-width: 400px;
+        box-shadow: 0 4px 32px rgba(0, 0, 0, 0.2);
+        margin: 0.5rem;
+        max-height: 90vh;
+        overflow-y: auto;
+      }
     
     @media (min-width: 768px) {
       .modal-content {
@@ -2188,12 +2220,14 @@ input, button, select, textarea {
       width: 100%;
       max-width: 100%;
       padding: 0.75rem;
-      border: 1px solid #ddd;
+      border: 1px solid #555;
       border-radius: 4px;
       font-size: 1rem;
       box-sizing: border-box;
       overflow: hidden;
       text-overflow: ellipsis;
+      background: #fff;
+      color: #000;
     }
     
     /* Specific styling for date inputs to prevent overflow */
@@ -2202,6 +2236,8 @@ input, button, select, textarea {
       padding: 0.6rem;
       -webkit-appearance: none;
       appearance: none;
+      background: #fff;
+      color: #000;
     }
     
     @media (max-width: 768px) {

--- a/login.html
+++ b/login.html
@@ -10,7 +10,20 @@
     .container { max-width: 400px; margin: 2rem auto; background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
     h2 { margin-bottom: 1.5rem; }
     label { display: block; margin-bottom: 0.5rem; font-weight: 500; }
-    input { width: 100%; padding: 0.75rem; margin-bottom: 1.25rem; border-radius: 8px; border: 1px solid #ccc; font-size: 1rem; }
+    input {
+      width: 100%;
+      padding: 0.75rem;
+      margin-bottom: 1.25rem;
+      border-radius: 8px;
+      border: 1px solid #555;
+      font-size: 1rem;
+      background: #fff;
+      color: #000;
+    }
+    input:focus {
+      border-color: #007aff;
+      outline: 2px solid rgba(0,122,255,0.4);
+    }
     button { width: 100%; padding: 0.75rem; border-radius: 8px; border: none; background: #007aff; color: #fff; font-size: 1.1rem; font-weight: 600; cursor: pointer; }
     button:hover { background: #005bb5; }
     .message { margin-top: 1rem; color: #e53e3e; font-weight: 500; }

--- a/update_credentials.html
+++ b/update_credentials.html
@@ -9,7 +9,20 @@
     .container { max-width: 400px; margin: 2rem auto; background: #fff; padding: 2rem; border-radius: 12px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
     h2 { margin-bottom: 1.5rem; }
     label { display: block; margin-bottom: 0.5rem; font-weight: 500; }
-    input { width: 100%; padding: 0.75rem; margin-bottom: 1.25rem; border-radius: 8px; border: 1px solid #ccc; font-size: 1rem; }
+    input {
+      width: 100%;
+      padding: 0.75rem;
+      margin-bottom: 1.25rem;
+      border-radius: 8px;
+      border: 1px solid #555;
+      font-size: 1rem;
+      background: #fff;
+      color: #000;
+    }
+    input:focus {
+      border-color: #007aff;
+      outline: 2px solid rgba(0,122,255,0.4);
+    }
     button { width: 100%; padding: 0.75rem; border-radius: 8px; border: none; background: #007aff; color: #fff; font-size: 1.1rem; font-weight: 600; cursor: pointer; }
     button:hover { background: #005bb5; }
     .message { margin-top: 1rem; color: #007aff; font-weight: 500; }


### PR DESCRIPTION
## Summary
- tweak modal styling for improved contrast in light and dark modes
- ensure text inputs and date pickers follow high-contrast guidelines

## Testing
- `node check_console.js >/tmp/console.log && cat /tmp/console.log` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_688308d5ec348328846f435457ea9489