### PR TITLE
Add connection summary page

### DIFF
--- a/connection_summary.html
+++ b/connection_summary.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Connection Summary</title>
+  <link rel="icon" type="image/png" href="https://i.imgur.com/KEqrcrK.png">
+  <link rel="apple-touch-icon" href="https://i.imgur.com/KEqrcrK.png">
+  <style id="dark-mode-style">
+    body.dark-mode { background: #181a1b; color: #e0e0e0; }
+    body.dark-mode select,
+    body.dark-mode input { background: #232527; color: #f3f4f6; }
+    body.dark-mode table { background: #232527; color: #e0e0e0; border-color: #333; }
+    body.dark-mode th { background: #181a1b; color: #e0e0e0; }
+  </style>
+  <style>
+    body { font-family: sans-serif; padding: 0.5rem; background: #f4f4f4; color: #222; }
+    .main-action-menu { position: relative; display: inline-block; }
+    .main-action-menu-btn { background: #007bff; color: #fff; border: 1px solid #007bff; border-radius: 4px; padding: 0.75rem 1rem; font-size: 1rem; cursor: pointer; font-weight: bold; }
+    .main-action-menu-dropdown { position: absolute; top: 100%; right: 0; background: white; border: 1px solid #dee2e6; border-radius: 4px; box-shadow: 0 2px 10px rgba(0,0,0,0.1); z-index: 1000; min-width: 180px; display: none; }
+    .main-action-menu-dropdown.show { display: block; }
+    .main-action-menu-item { padding: 0.75rem 1rem; cursor: pointer; background: none; width: 100%; text-align: left; font-size: 0.9rem; color: #495057; border: none; }
+    table { width: 100%; border-collapse: collapse; }
+    th, td { padding: 0.5rem; border: 1px solid #ccc; }
+    th.sortable { cursor: pointer; }
+    .btn-primary { background: #007bff; color: #fff; border: none; padding: 0.5rem 1rem; border-radius: 4px; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;gap:0.5rem;">
+    <div onclick="window.location.href='index.html'" style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
+      <img id="radius-logo" src="https://i.imgur.com/aofM4G4.png" alt="Radius Logo" style="height:32px;width:auto;">
+      <h1 style="margin:0;font-size:1.5rem;">Radius</h1>
+    </div>
+    <div class="main-action-menu">
+      <button class="main-action-menu-btn" id="main-actions-btn">Menu ▼</button>
+      <div class="main-action-menu-dropdown" id="main-actions-dropdown">
+        <button class="main-action-menu-item" onclick="window.location.href='index.html'">Dashboard</button>
+        <button class="main-action-menu-item" id="dark-mode-toggle">Toggle Dark Mode</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="communication-summary" style="margin-top:2rem;">
+    <h2 style="color:#333;border-bottom:2px solid #007bff;padding-bottom:0.5rem;margin-bottom:1rem;font-size:1.3rem;">Connection Summary</h2>
+    <div style="display:flex;gap:0.5rem;align-items:center;margin-bottom:1rem;flex-wrap:wrap;">
+      <select id="summary-month" style="padding:0.5rem;flex:1;min-width:120px;font-size:0.9rem;"></select>
+      <select id="summary-year" style="padding:0.5rem;flex:1;min-width:80px;font-size:0.9rem;"></select>
+      <button id="apply-summary-filter" class="btn-primary" style="padding:0.75rem 1rem;font-size:0.9rem;flex-shrink:0;">Apply</button>
+    </div>
+    <div style="margin-bottom:1.5rem;">
+      <h3>One-on-One Meetings</h3>
+      <table id="one-on-one-table">
+        <thead><tr><th class="sortable" data-column="name">Name</th><th class="sortable" data-column="date">Date</th><th class="sortable" data-column="status">Status</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div style="margin-bottom:1.5rem;">
+      <h3>Circle Leader Lunch</h3>
+      <table id="lunch-table">
+        <thead><tr><th class="sortable" data-column="name">Name</th><th class="sortable" data-column="date">Date</th><th class="sortable" data-column="status">Status</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div style="margin-bottom:1.5rem;">
+      <h3>Circle Visit</h3>
+      <table id="visit-table">
+        <thead><tr><th class="sortable" data-column="name">Name</th><th class="sortable" data-column="date">Date</th><th class="sortable" data-column="status">Status</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script>
+    const supabaseUrl = 'https://eruboulvrgrodccmjjbe.supabase.co';
+    const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVydWJvdWx2cmdyb2RjY21qamJlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMwOTMzOTUsImV4cCI6MjA2ODY2OTM5NX0.FJ0nu1Ov8jbAdZy8SX9qs2gJ60_qdROsIkwRg8k9GK0';
+    const client = supabase.createClient(supabaseUrl, supabaseKey);
+
+    let selectedSummaryMonth = null;
+    let selectedSummaryYear = null;
+
+    function formatDateOnly(dateStr) {
+      if (!dateStr) return '';
+      const d = new Date(dateStr);
+      return d.toISOString().split('T')[0];
+    }
+    function formatStatusDisplay(status) { return status ? status.charAt(0).toUpperCase() + status.slice(1) : ''; }
+
+    function populateTable(tableId, data) {
+      const tbody = document.querySelector(`#${tableId} tbody`);
+      tbody.innerHTML = '';
+      if (data.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:#666;font-style:italic;">No entries found</td></tr>';
+        return;
+      }
+      data.forEach(item => {
+        const row = document.createElement('tr');
+        row.innerHTML = `<td>${item.name}</td><td>${formatDateOnly(item.date)}</td><td>${formatStatusDisplay(item.status)}</td>`;
+        tbody.appendChild(row);
+      });
+    }
+
+    async function loadOneOnOneMeetings() {
+      const firstDay = new Date(selectedSummaryYear, selectedSummaryMonth, 1).toISOString().split('T')[0];
+      const lastDay = new Date(selectedSummaryYear, selectedSummaryMonth + 1, 0).toISOString().split('T')[0];
+      const { data: comments } = await client.from('circle_comments').select('*, circle_leaders!inner(full_name, status)').ilike('comment', '%One-on-One%').gte('created_at', firstDay).lte('created_at', lastDay + 'T23:59:59');
+      const { data: leaders } = await client.from('circle_leaders').select('*').eq('last_comm_type', 'One-on-One').gte('last_comm_date', firstDay).lte('last_comm_date', lastDay);
+      const meetingsMap = new Map();
+      comments?.forEach(c => { const date = (c.comment.match(/One-on-One on (\d{4}-\d{2}-\d{2})/)||[])[1] || c.created_at.split('T')[0]; if(date>=firstDay&&date<=lastDay){ const key=c.leader_id; if(!meetingsMap.has(key)||meetingsMap.get(key).date<date){ meetingsMap.set(key,{name:c.circle_leaders.full_name,date, status:c.circle_leaders.status}); } } });
+      leaders?.forEach(l => { if(l.last_comm_date && l.last_comm_date>=firstDay && l.last_comm_date<=lastDay){ const key=l.id; if(!meetingsMap.has(key)||meetingsMap.get(key).date<l.last_comm_date){ meetingsMap.set(key,{name:l.full_name,date:l.last_comm_date,status:l.status}); } } });
+      populateTable('one-on-one-table', Array.from(meetingsMap.values()));
+    }
+    async function loadTrainingSessions() { /* omitted on summary page */ }
+    async function loadLunchMeetings() {
+      const firstDay = new Date(selectedSummaryYear, selectedSummaryMonth, 1).toISOString().split('T')[0];
+      const lastDay = new Date(selectedSummaryYear, selectedSummaryMonth + 1, 0).toISOString().split('T')[0];
+      const { data: comments } = await client.from('circle_comments').select('*, circle_leaders!inner(full_name, status)').ilike('comment', '%Circle Leader Lunch%').gte('created_at', firstDay).lte('created_at', lastDay + 'T23:59:59');
+      const { data: leaders } = await client.from('circle_leaders').select('*').eq('last_comm_type', 'Circle Leader Lunch').gte('last_comm_date', firstDay).lte('last_comm_date', lastDay);
+      const map = new Map();
+      comments?.forEach(c => { const date=(c.comment.match(/Circle Leader Lunch on (\d{4}-\d{2}-\d{2})/)||[])[1]||c.created_at.split('T')[0]; if(date>=firstDay&&date<=lastDay){ const key=c.leader_id; if(!map.has(key)||map.get(key).date<date){ map.set(key,{name:c.circle_leaders.full_name,date,status:c.circle_leaders.status}); } } });
+      leaders?.forEach(l=>{ if(l.last_comm_date && l.last_comm_date>=firstDay && l.last_comm_date<=lastDay){ const key=l.id; if(!map.has(key)||map.get(key).date<l.last_comm_date){ map.set(key,{name:l.full_name,date:l.last_comm_date,status:l.status}); } } });
+      populateTable('lunch-table', Array.from(map.values()));
+    }
+    async function loadCircleVisits() {
+      const firstDay = new Date(selectedSummaryYear, selectedSummaryMonth, 1).toISOString().split('T')[0];
+      const lastDay = new Date(selectedSummaryYear, selectedSummaryMonth + 1, 0).toISOString().split('T')[0];
+      const { data: comments } = await client.from('circle_comments').select('*, circle_leaders!inner(full_name, status)').ilike('comment', '%Circle Visit%').gte('created_at', firstDay).lte('created_at', lastDay + 'T23:59:59');
+      const { data: leaders } = await client.from('circle_leaders').select('*').eq('last_comm_type', 'Circle Visit').gte('last_comm_date', firstDay).lte('last_comm_date', lastDay);
+      const map=new Map();
+      comments?.forEach(c=>{ const date=(c.comment.match(/Circle Visit on (\d{4}-\d{2}-\d{2})/)||[])[1]||c.created_at.split('T')[0]; if(date>=firstDay&&date<=lastDay){ const key=c.leader_id; if(!map.has(key)||map.get(key).date<date){ map.set(key,{name:c.circle_leaders.full_name,date,status:c.circle_leaders.status}); } } });
+      leaders?.forEach(l=>{ if(l.last_comm_date && l.last_comm_date>=firstDay && l.last_comm_date<=lastDay){ const key=l.id; if(!map.has(key)||map.get(key).date<l.last_comm_date){ map.set(key,{name:l.full_name,date:l.last_comm_date,status:l.status}); } } });
+      populateTable('visit-table', Array.from(map.values()));
+    }
+    async function loadCommunicationSummaries() {
+      await loadOneOnOneMeetings();
+      await loadLunchMeetings();
+      await loadCircleVisits();
+    }
+    function initializeSummaryFilters() {
+      const now=new Date();
+      selectedSummaryMonth=now.getMonth();
+      selectedSummaryYear=now.getFullYear();
+      const yearSelect=document.getElementById('summary-year');
+      for(let y=selectedSummaryYear-2;y<=selectedSummaryYear+2;y++){ const opt=document.createElement('option'); opt.value=y; opt.textContent=y; if(y===selectedSummaryYear) opt.selected=true; yearSelect.appendChild(opt); }
+      document.getElementById('summary-month').innerHTML=["January","February","March","April","May","June","July","August","September","October","November","December"].map((m,i)=>`<option value="${i}"${i===selectedSummaryMonth?' selected':''}>${m}</option>`).join('');
+    }
+    document.getElementById('apply-summary-filter').addEventListener('click', () => { selectedSummaryMonth=parseInt(document.getElementById('summary-month').value); selectedSummaryYear=parseInt(document.getElementById('summary-year').value); loadCommunicationSummaries(); });
+    initializeSummaryFilters();
+    loadCommunicationSummaries();
+
+    const mainActionsBtn=document.getElementById('main-actions-btn');
+    const mainActionsDropdown=document.getElementById('main-actions-dropdown');
+    mainActionsBtn.addEventListener('click',()=>{ mainActionsDropdown.classList.toggle('show'); });
+    document.addEventListener('click', e=>{ if(!mainActionsDropdown.contains(e.target) && e.target!==mainActionsBtn){ mainActionsDropdown.classList.remove('show'); } });
+    const darkToggle=document.getElementById('dark-mode-toggle');
+    function setDarkMode(enabled){ if(enabled){ document.body.classList.add('dark-mode'); darkToggle.textContent='Light Mode'; } else { document.body.classList.remove('dark-mode'); darkToggle.textContent='Dark Mode'; } localStorage.setItem('radius-dark-mode', enabled ? '1' : '0'); }
+    darkToggle.addEventListener('click', ()=>{ setDarkMode(!document.body.classList.contains('dark-mode')); });
+    if(localStorage.getItem('radius-dark-mode')==='1'){ setDarkMode(true); }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1561,6 +1561,7 @@ body.dark-mode .status-container .status {
       <div class="main-action-menu-dropdown" id="main-actions-dropdown">
         <button class="main-action-menu-item" id="search-circles-btn">Search Circles</button>
         <button class="main-action-menu-item" id="add-leader-btn-menu">Add New Leader</button>
+        <button class="main-action-menu-item" onclick="window.location.href='connection_summary.html'">Connection Summary</button>
         <button class="main-action-menu-item" id="dark-mode-toggle">Toggle Dark Mode</button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `connection_summary.html` with a simplified connection summary view
- link new page from the header menu

## Testing
- `node -e "console.log('hello')"`
- `npm install puppeteer` *(fails: missing system libraries)*
- `node` supabase test *(fails: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_688309106574832883769e000d8d298c