### PR TITLE
Refine connection summary table

### DIFF
--- a/connection_summary.html
+++ b/connection_summary.html
@@ -1,0 +1,471 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Connection Summary</title>
+  <link rel="icon" type="image/png" href="https://i.imgur.com/aofM4G4.png">
+  <link rel="apple-touch-icon" href="https://i.imgur.com/aofM4G4.png">
+  <style id="dark-mode-style">
+    body.dark-mode {
+      background: #181a1b;
+      color: #e0e0e0;
+    }
+    body.dark-mode select,
+    body.dark-mode input {
+      background: #232527;
+      color: #f3f4f6;
+      border-color: #333;
+    }
+    body.dark-mode table,
+    body.dark-mode th,
+    body.dark-mode td {
+      background: #232527;
+      color: #e0e0e0;
+      border-color: #333;
+    }
+    body.dark-mode thead th {
+      background: #181a1b;
+      border-bottom: 2px solid #007aff;
+    }
+    body.dark-mode .main-action-menu-item:hover {
+      background: #374151 !important;
+      color: #f3f4f6 !important;
+    }
+    body.dark-mode .btn-primary {
+      background: #007aff !important;
+      color: #fff !important;
+      border-color: #007aff !important;
+    }
+  </style>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 0.5rem;
+      background: #f4f4f4;
+      color: #222;
+      margin: 0;
+    }
+    .main-action-menu {
+      position: relative;
+      display: inline-block;
+      margin-bottom: 1rem;
+    }
+    .main-action-menu-btn {
+      background: #007bff;
+      color: white;
+      border: 1px solid #007bff;
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      font-size: 1rem;
+      cursor: pointer;
+      font-weight: bold;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .main-action-menu-btn:hover {
+      background: #0056b3;
+      border-color: #0056b3;
+    }
+    .main-action-menu-dropdown {
+      position: absolute;
+      top: 100%;
+      right: 0;
+      background: white;
+      border: 1px solid #dee2e6;
+      border-radius: 4px;
+      box-shadow: 0 2px 10px rgba(0,0,0,0.1);
+      z-index: 1000;
+      min-width: 180px;
+      display: none;
+    }
+    .main-action-menu-dropdown.show {
+      display: block;
+    }
+    .main-action-menu-item {
+      padding: 0.75rem 1rem;
+      cursor: pointer;
+      border: none;
+      background: none;
+      width: 100%;
+      text-align: left;
+      font-size: 0.9rem;
+      color: #495057;
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .main-action-menu-item:hover {
+      background: #f8f9fa;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 0.5rem;
+      border-radius: 16px;
+      overflow: hidden;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.04);
+      background: #fff;
+      font-size: 0.85rem;
+    }
+    th, td {
+      padding: 1rem 0.75rem;
+      border: 1px solid #e0e0e0;
+      background: #fff;
+      color: #222;
+      font-size: 17px;
+    }
+    thead th {
+      background: #f4f4f4;
+      font-weight: 700;
+      color: #222;
+      border-bottom: 2px solid #007aff;
+    }
+    tbody tr:hover {
+      background: #e9ecef;
+    }
+    .name-link {
+      color: #007bff;
+      text-decoration: none;
+      font-weight: bold;
+    }
+    .name-link:hover {
+      text-decoration: underline;
+    }
+    .profile-status {
+      display: inline-block;
+      padding: 0.25rem 0.75rem;
+      border-radius: 15px;
+      font-size: 0.875rem;
+      font-weight: bold;
+      text-transform: capitalize;
+    }
+    .status-active {
+      background: #d4edda;
+      color: #155724;
+    }
+    .status-pipeline {
+      background: #fff3cd;
+      color: #856404;
+    }
+    .status-invite {
+      background: #f8d7da;
+      color: #721c24;
+    }
+    .status-paused {
+      background: #e2e3e5;
+      color: #383d41;
+    }
+    .sortable {
+      cursor: pointer;
+      user-select: none;
+      position: relative;
+    }
+    .sort-indicator {
+      margin-left: 5px;
+      font-size: 0.8em;
+    }
+    .sort-asc::after { content: "▲"; }
+    .sort-desc::after { content: "▼"; }
+    select, input, button {
+      margin: 0.5rem 0;
+      padding: 1rem;
+      font-size: 17px;
+      border: 1px solid #ddd;
+      border-radius: 12px;
+      box-sizing: border-box;
+      min-height: 44px;
+    }
+    .btn-primary {
+      background: #007aff;
+      color: #fff;
+      border: 2px solid #007aff;
+      border-radius: 12px;
+      font-weight: 600;
+      transition: background 0.2s;
+      cursor: pointer;
+    }
+    .btn-primary:hover {
+      filter: brightness(0.95);
+    }
+  </style>
+</head>
+<body>
+  <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:1rem;gap:0.5rem;">
+    <div onclick="window.location.href='index.html'" style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;">
+      <img id="radius-logo" src="https://i.imgur.com/aofM4G4.png" alt="Radius Logo" style="height:32px;width:auto;">
+      <h1 style="margin:0;font-size:1.5rem;">Radius</h1>
+    </div>
+    <div class="main-action-menu">
+      <button class="main-action-menu-btn" id="main-actions-btn">Menu ▼</button>
+      <div class="main-action-menu-dropdown" id="main-actions-dropdown">
+        <button class="main-action-menu-item" onclick="window.location.href='index.html'">Dashboard</button>
+        <button class="main-action-menu-item" id="dark-mode-toggle">Toggle Dark Mode</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="communication-summary" style="margin-top:2rem;">
+    <h2 style="color:#333;border-bottom:2px solid #007bff;padding-bottom:0.5rem;margin-bottom:1rem;font-size:1.3rem;">Connection Summary</h2>
+    <div style="display:flex;gap:0.5rem;align-items:center;margin-bottom:1rem;flex-wrap:wrap;">
+      <select id="summary-month" style="padding:0.5rem;flex:1;min-width:120px;font-size:0.9rem;"></select>
+      <select id="summary-year" style="padding:0.5rem;flex:1;min-width:80px;font-size:0.9rem;"></select>
+      <button id="apply-summary-filter" class="btn-primary" style="padding:0.75rem 1rem;font-size:0.9rem;flex-shrink:0;">Apply</button>
+    </div>
+    <div style="margin-bottom:1.5rem;">
+      <h3>One-on-One Meetings</h3>
+      <table id="one-on-one-table">
+        <thead><tr><th class="sortable" data-column="name">Name</th><th class="sortable" data-column="date">Date</th><th class="sortable" data-column="status">Status</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div style="margin-bottom:1.5rem;">
+      <h3>Circle Leader Lunch</h3>
+      <table id="lunch-table">
+        <thead><tr><th class="sortable" data-column="name">Name</th><th class="sortable" data-column="date">Date</th><th class="sortable" data-column="status">Status</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div style="margin-bottom:1.5rem;">
+      <h3>Circle Visit</h3>
+      <table id="visit-table">
+        <thead><tr><th class="sortable" data-column="name">Name</th><th class="sortable" data-column="date">Date</th><th class="sortable" data-column="status">Status</th></tr></thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script>
+    const supabaseUrl = 'https://eruboulvrgrodccmjjbe.supabase.co';
+    const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImVydWJvdWx2cmdyb2RjY21qamJlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMwOTMzOTUsImV4cCI6MjA2ODY2OTM5NX0.FJ0nu1Ov8jbAdZy8SX9qs2gJ60_qdROsIkwRg8k9GK0';
+    const client = supabase.createClient(supabaseUrl, supabaseKey);
+
+    let selectedSummaryMonth = null;
+    let selectedSummaryYear = null;
+
+    function formatDateOnly(dateStr) {
+      if (!dateStr) return '';
+      const d = new Date(dateStr);
+      return d.toISOString().split('T')[0];
+    }
+    function getStatusClass(status) {
+      if (!status) return '';
+      return `status-${status.toLowerCase()}`;
+    }
+
+    function formatStatusDisplay(status) {
+      if (!status) return '';
+      const statusClass = getStatusClass(status);
+      const displayText = status === 'active' ? 'Active' :
+                         status === 'invite' ? 'Invite' :
+                         status === 'pipeline' ? 'Pipeline' :
+                         status === 'paused' ? 'Paused' : status;
+      return `<span class="profile-status ${statusClass}">${displayText}</span>`;
+    }
+
+    const tableData = {
+      'one-on-one-table': [],
+      'lunch-table': [],
+      'visit-table': []
+    };
+
+    const tableSortStates = {
+      'one-on-one-table': { column: null, direction: 'asc' },
+      'lunch-table': { column: null, direction: 'asc' },
+      'visit-table': { column: null, direction: 'asc' }
+    };
+
+    function populateTable(tableId, data) {
+      if (!arguments[2]) {
+        tableData[tableId] = [...data];
+
+        const sortState = tableSortStates[tableId];
+        if (sortState && sortState.column) {
+          data.sort((a, b) => {
+            let aVal = a[sortState.column] || '';
+            let bVal = b[sortState.column] || '';
+            if (sortState.column === 'date') {
+              aVal = aVal || '1900-01-01';
+              bVal = bVal || '1900-01-01';
+            }
+            aVal = aVal.toString().toLowerCase();
+            bVal = bVal.toString().toLowerCase();
+            if (aVal < bVal) return sortState.direction === 'asc' ? -1 : 1;
+            if (aVal > bVal) return sortState.direction === 'asc' ? 1 : -1;
+            return 0;
+          });
+
+          const headers = document.querySelectorAll(`#${tableId} .sortable`);
+          headers.forEach(h => {
+            h.classList.remove('sort-asc', 'sort-desc');
+            if (h.dataset.column === sortState.column) {
+              h.classList.add(sortState.direction === 'asc' ? 'sort-asc' : 'sort-desc');
+            }
+          });
+        }
+      }
+
+      const tbody = document.querySelector(`#${tableId} tbody`);
+      tbody.innerHTML = '';
+      if (data.length === 0) {
+        tbody.innerHTML = '<tr><td colspan="3" style="text-align:center;color:#666;font-style:italic;">No entries found</td></tr>';
+        return;
+      }
+      data.forEach(item => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td><a href="index.html?leader_id=${item.id}" class="name-link" data-leader-id="${item.id}">${item.name}</a></td>
+          <td>${formatDateOnly(item.date)}</td>
+          <td>${formatStatusDisplay(item.status)}</td>`;
+        tbody.appendChild(row);
+      });
+    }
+
+    function sortTableData(tableId, column, direction) {
+      const data = tableData[tableId];
+      if (!data || data.length === 0) return;
+
+      data.sort((a, b) => {
+        let aVal = a[column] || '';
+        let bVal = b[column] || '';
+        if (column === 'date') {
+          aVal = aVal || '1900-01-01';
+          bVal = bVal || '1900-01-01';
+        }
+        aVal = aVal.toString().toLowerCase();
+        bVal = bVal.toString().toLowerCase();
+        if (aVal < bVal) return direction === 'asc' ? -1 : 1;
+        if (aVal > bVal) return direction === 'asc' ? 1 : -1;
+        return 0;
+      });
+
+      populateTable(tableId, data, true);
+    }
+
+    async function loadOneOnOneMeetings() {
+      const firstDay = new Date(selectedSummaryYear, selectedSummaryMonth, 1).toISOString().split('T')[0];
+      const lastDay = new Date(selectedSummaryYear, selectedSummaryMonth + 1, 0).toISOString().split('T')[0];
+      const { data: comments } = await client.from('circle_comments').select('*, circle_leaders!inner(full_name, status)').ilike('comment', '%One-on-One%').gte('created_at', firstDay).lte('created_at', lastDay + 'T23:59:59');
+      const { data: leaders } = await client.from('circle_leaders').select('*').eq('last_comm_type', 'One-on-One').gte('last_comm_date', firstDay).lte('last_comm_date', lastDay);
+      const meetingsMap = new Map();
+      comments?.forEach(c => {
+        const date = (c.comment.match(/One-on-One on (\d{4}-\d{2}-\d{2})/)||[])[1] || c.created_at.split('T')[0];
+        if(date>=firstDay && date<=lastDay){
+          const key = c.leader_id;
+          if(!meetingsMap.has(key) || meetingsMap.get(key).date < date){
+            meetingsMap.set(key,{id:key,name:c.circle_leaders.full_name,date,status:c.circle_leaders.status});
+          }
+        }
+      });
+      leaders?.forEach(l => {
+        if(l.last_comm_date && l.last_comm_date>=firstDay && l.last_comm_date<=lastDay){
+          const key=l.id;
+          if(!meetingsMap.has(key) || meetingsMap.get(key).date < l.last_comm_date){
+            meetingsMap.set(key,{id:key,name:l.full_name,date:l.last_comm_date,status:l.status});
+          }
+        }
+      });
+      populateTable('one-on-one-table', Array.from(meetingsMap.values()));
+    }
+    async function loadTrainingSessions() { /* omitted on summary page */ }
+    async function loadLunchMeetings() {
+      const firstDay = new Date(selectedSummaryYear, selectedSummaryMonth, 1).toISOString().split('T')[0];
+      const lastDay = new Date(selectedSummaryYear, selectedSummaryMonth + 1, 0).toISOString().split('T')[0];
+      const { data: comments } = await client.from('circle_comments').select('*, circle_leaders!inner(full_name, status)').ilike('comment', '%Circle Leader Lunch%').gte('created_at', firstDay).lte('created_at', lastDay + 'T23:59:59');
+      const { data: leaders } = await client.from('circle_leaders').select('*').eq('last_comm_type', 'Circle Leader Lunch').gte('last_comm_date', firstDay).lte('last_comm_date', lastDay);
+      const map = new Map();
+      comments?.forEach(c => {
+        const date=(c.comment.match(/Circle Leader Lunch on (\d{4}-\d{2}-\d{2})/)||[])[1]||c.created_at.split('T')[0];
+        if(date>=firstDay && date<=lastDay){
+          const key=c.leader_id;
+          if(!map.has(key) || map.get(key).date<date){
+            map.set(key,{id:key,name:c.circle_leaders.full_name,date,status:c.circle_leaders.status});
+          }
+        }
+      });
+      leaders?.forEach(l=>{
+        if(l.last_comm_date && l.last_comm_date>=firstDay && l.last_comm_date<=lastDay){
+          const key=l.id;
+          if(!map.has(key) || map.get(key).date<l.last_comm_date){
+            map.set(key,{id:key,name:l.full_name,date:l.last_comm_date,status:l.status});
+          }
+        }
+      });
+      populateTable('lunch-table', Array.from(map.values()));
+    }
+    async function loadCircleVisits() {
+      const firstDay = new Date(selectedSummaryYear, selectedSummaryMonth, 1).toISOString().split('T')[0];
+      const lastDay = new Date(selectedSummaryYear, selectedSummaryMonth + 1, 0).toISOString().split('T')[0];
+      const { data: comments } = await client.from('circle_comments').select('*, circle_leaders!inner(full_name, status)').ilike('comment', '%Circle Visit%').gte('created_at', firstDay).lte('created_at', lastDay + 'T23:59:59');
+      const { data: leaders } = await client.from('circle_leaders').select('*').eq('last_comm_type', 'Circle Visit').gte('last_comm_date', firstDay).lte('last_comm_date', lastDay);
+      const map=new Map();
+      comments?.forEach(c=>{ 
+        const date=(c.comment.match(/Circle Visit on (\d{4}-\d{2}-\d{2})/)||[])[1]||c.created_at.split('T')[0];
+        if(date>=firstDay && date<=lastDay){
+          const key=c.leader_id;
+          if(!map.has(key) || map.get(key).date<date){
+            map.set(key,{id:key,name:c.circle_leaders.full_name,date,status:c.circle_leaders.status});
+          }
+        }
+      });
+      leaders?.forEach(l=>{
+        if(l.last_comm_date && l.last_comm_date>=firstDay && l.last_comm_date<=lastDay){
+          const key=l.id;
+          if(!map.has(key) || map.get(key).date<l.last_comm_date){
+            map.set(key,{id:key,name:l.full_name,date:l.last_comm_date,status:l.status});
+          }
+        }
+      });
+      populateTable('visit-table', Array.from(map.values()));
+    }
+    async function loadCommunicationSummaries() {
+      await loadOneOnOneMeetings();
+      await loadLunchMeetings();
+      await loadCircleVisits();
+    }
+    function initializeSummaryFilters() {
+      const now=new Date();
+      selectedSummaryMonth=now.getMonth();
+      selectedSummaryYear=now.getFullYear();
+      const yearSelect=document.getElementById('summary-year');
+      for(let y=selectedSummaryYear-2;y<=selectedSummaryYear+2;y++){ const opt=document.createElement('option'); opt.value=y; opt.textContent=y; if(y===selectedSummaryYear) opt.selected=true; yearSelect.appendChild(opt); }
+      document.getElementById('summary-month').innerHTML=["January","February","March","April","May","June","July","August","September","October","November","December"].map((m,i)=>`<option value="${i}"${i===selectedSummaryMonth?' selected':''}>${m}</option>`).join('');
+    }
+    document.getElementById('apply-summary-filter').addEventListener('click', () => { selectedSummaryMonth=parseInt(document.getElementById('summary-month').value); selectedSummaryYear=parseInt(document.getElementById('summary-year').value); loadCommunicationSummaries(); });
+    initializeSummaryFilters();
+    loadCommunicationSummaries();
+
+    document.querySelectorAll('.sortable').forEach(header => {
+      header.addEventListener('click', () => {
+        const column = header.dataset.column;
+        const tableId = header.closest('table').id;
+        const currentSort = tableSortStates[tableId];
+        if (currentSort.column === column) {
+          currentSort.direction = currentSort.direction === 'asc' ? 'desc' : 'asc';
+        } else {
+          currentSort.column = column;
+          currentSort.direction = 'asc';
+        }
+
+        document.querySelectorAll(`#${tableId} .sortable`).forEach(h => h.classList.remove('sort-asc', 'sort-desc'));
+        header.classList.add(currentSort.direction === 'asc' ? 'sort-asc' : 'sort-desc');
+
+        sortTableData(tableId, column, currentSort.direction);
+      });
+    });
+
+    const mainActionsBtn=document.getElementById('main-actions-btn');
+    const mainActionsDropdown=document.getElementById('main-actions-dropdown');
+    mainActionsBtn.addEventListener('click',()=>{ mainActionsDropdown.classList.toggle('show'); });
+    document.addEventListener('click', e=>{ if(!mainActionsDropdown.contains(e.target) && e.target!==mainActionsBtn){ mainActionsDropdown.classList.remove('show'); } });
+    const darkToggle=document.getElementById('dark-mode-toggle');
+    function setDarkMode(enabled){ if(enabled){ document.body.classList.add('dark-mode'); darkToggle.textContent='Light Mode'; } else { document.body.classList.remove('dark-mode'); darkToggle.textContent='Dark Mode'; } localStorage.setItem('radius-dark-mode', enabled ? '1' : '0'); }
+    darkToggle.addEventListener('click', ()=>{ setDarkMode(!document.body.classList.contains('dark-mode')); });
+    if(localStorage.getItem('radius-dark-mode')==='1'){ setDarkMode(true); }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -366,8 +366,6 @@ body.dark-mode #filter-container option {
   appearance: none !important;
 }
 
-body.dark-mode #summary-month,
-body.dark-mode #summary-year {
   background-color: #232527 !important;
   color: #e0e0e0 !important;
   border: 2px solid #333 !important;
@@ -377,8 +375,6 @@ body.dark-mode #summary-year {
   appearance: none !important;
 }
 
-body.dark-mode #summary-month:focus,
-body.dark-mode #summary-year:focus {
   background: #232527 !important;
   color: #66aaff !important;
   border-color: #66aaff !important;
@@ -1561,6 +1557,7 @@ body.dark-mode .status-container .status {
       <div class="main-action-menu-dropdown" id="main-actions-dropdown">
         <button class="main-action-menu-item" id="search-circles-btn">Search Circles</button>
         <button class="main-action-menu-item" id="add-leader-btn-menu">Add New Leader</button>
+        <button class="main-action-menu-item" onclick="window.location.href='connection_summary.html'">Connection Summary</button>
         <button class="main-action-menu-item" id="dark-mode-toggle">Toggle Dark Mode</button>
       </div>
     </div>
@@ -2619,83 +2616,6 @@ body.dark-mode .status-container .status {
       </tbody>
     </table>
 
-    <!-- Communication Summary Tables -->
-    <div id="communication-summary" style="margin-top: 2rem;">
-      <h2 style="color: #333; border-bottom: 2px solid #007bff; padding-bottom: 0.5rem; margin-bottom: 1rem; font-size: 1.3rem;">Connection Summary</h2>
-      <div style="display: flex; gap: 0.5rem; align-items: center; margin-bottom: 1rem; flex-wrap: wrap;">
-        <select id="summary-month" style="padding: 0.5rem; flex: 1; min-width: 120px; font-size: 0.9rem;">
-          <option value="0">January</option>
-          <option value="1">February</option>
-          <option value="2">March</option>
-          <option value="3">April</option>
-          <option value="4">May</option>
-          <option value="5">June</option>
-          <option value="6">July</option>
-          <option value="7">August</option>
-          <option value="8">September</option>
-          <option value="9">October</option>
-          <option value="10">November</option>
-          <option value="11">December</option>
-        </select>
-        <select id="summary-year" style="padding: 0.5rem; flex: 1; min-width: 80px; font-size: 0.9rem;">
-          <!-- Years will be populated by JavaScript -->
-        </select>
-        <button id="apply-summary-filter" class="btn-primary" style="padding: 0.75rem 1rem; font-size: 0.9rem; width: auto; min-height: 44px; flex-shrink: 0;">Apply</button>
-      </div>
-      
-      <!-- One-on-One Table -->
-      <div style="margin-bottom: 1.5rem;">
-        <h3>One-on-One Meetings</h3>
-        <table id="one-on-one-table" class="px-4 py-2" style="margin-top: 0.5rem; border-radius: 2px">
-          <thead>
-            <tr>
-              <th class="sortable" data-column="name" data-table="one-on-one-table">Name <span class="sort-indicator"></span></th>
-              <th class="sortable" data-column="date" data-table="one-on-one-table">Date <span class="sort-indicator"></span></th>
-              <th class="sortable" data-column="status" data-table="one-on-one-table">Status <span class="sort-indicator"></span></th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Data will be populated here -->
-          </tbody>
-        </table>
-      </div>
-
-
-
-      <!-- Circle Leader Lunch Table -->
-      <div style="margin-bottom: 1.5rem;">
-        <h3>Circle Leader Lunch</h3>
-        <table id="lunch-table" class="px-4 py-2" style="margin-top: 0.5rem; border-radius: 2px">
-          <thead>
-            <tr>
-              <th class="sortable" data-column="name" data-table="lunch-table">Name <span class="sort-indicator"></span></th>
-              <th class="sortable" data-column="date" data-table="lunch-table">Date <span class="sort-indicator"></span></th>
-              <th class="sortable" data-column="status" data-table="lunch-table">Status <span class="sort-indicator"></span></th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Data will be populated here -->
-          </tbody>
-        </table>
-      </div>
-
-      <!-- Circle Visit Table -->
-      <div style="margin-bottom: 1.5rem;">
-        <h3>Circle Visit</h3>
-        <table id="visit-table" class="px-4 py-2" style="margin-top: 0.5rem; border-radius: 2px">
-          <thead>
-            <tr>
-              <th class="sortable" data-column="name" data-table="visit-table">Name <span class="sort-indicator"></span></th>
-              <th class="sortable" data-column="date" data-table="visit-table">Date <span class="sort-indicator"></span></th>
-              <th class="sortable" data-column="status" data-table="visit-table">Status <span class="sort-indicator"></span></th>
-            </tr>
-          </thead>
-          <tbody>
-            <!-- Data will be populated here -->
-          </tbody>
-        </table>
-      </div>
-    </div>
 
     <form id="edit-leader-form" style="display:none;">
       <h2>Edit Leader</h2>
@@ -3367,7 +3287,6 @@ function populateSearchResultsMobile(results) {
               } else {
                 currentLeader.last_comm_date = null;
                 currentLeader.last_comm_type = null;
-                loadCommunicationSummaries();
                 showLeaderProfile(currentLeader);
               }
             } catch (err) {
@@ -4108,7 +4027,6 @@ function populateSearchResultsMobile(results) {
       loadMeetingToday()
     }
 
-    async function loadCommunicationSummaries() {
       await loadOneOnOneMeetings()
       await loadTrainingSessions()
       await loadLunchMeetings()
@@ -4787,7 +4705,6 @@ function populateSearchResultsMobile(results) {
         setTimeout(() => clearStatus(), 3000)
         
         loadCircleLeaders()
-        loadCommunicationSummaries()
         hideAddLeaderPage()
         
       } catch (error) {
@@ -4843,7 +4760,6 @@ function populateSearchResultsMobile(results) {
       
       // Refresh the main list
       loadCircleLeaders()
-      loadCommunicationSummaries()
       
       // If we have a current leader, update their data and show the profile again
       if (currentLeader && currentLeader.id === id) {
@@ -4866,7 +4782,6 @@ function populateSearchResultsMobile(results) {
     let selectedSummaryYear = null
 
     // Initialize date filters
-    function initializeSummaryFilters() {
       const now = new Date()
       const currentMonth = now.getMonth()
       const currentYear = now.getFullYear()
@@ -4876,7 +4791,6 @@ function populateSearchResultsMobile(results) {
       selectedSummaryYear = currentYear
       
       // Populate year dropdown (current year +/- 2 years)
-      const yearSelect = document.getElementById('summary-year')
       for (let year = currentYear - 2; year <= currentYear + 2; year++) {
         const option = document.createElement('option')
         option.value = year
@@ -4886,7 +4800,6 @@ function populateSearchResultsMobile(results) {
       }
       
       // Set default month
-      document.getElementById('summary-month').value = currentMonth
     }
 
     // Action menu functionality
@@ -5056,7 +4969,6 @@ function populateSearchResultsMobile(results) {
         // Refresh the profile display and main list
         showLeaderProfile(currentLeader)
         loadCircleLeaders()
-        loadCommunicationSummaries()
         
         setStatus('Leader updated successfully!')
       } catch (error) {
@@ -5092,7 +5004,6 @@ function populateSearchResultsMobile(results) {
         // Return to the main list
         hideLeaderProfile()
         loadCircleLeaders()
-        loadCommunicationSummaries()
         
       } catch (error) {
         console.error('Error deleting leader:', error)
@@ -5437,7 +5348,6 @@ function populateSearchResultsMobile(results) {
         
         // Also refresh the main list
         loadCircleLeaders()
-        loadCommunicationSummaries()
         
         // Hide the modal
         document.getElementById('update-comm-modal').classList.add('hidden')
@@ -5506,7 +5416,6 @@ function populateSearchResultsMobile(results) {
         
         // Refresh notes and follow-up table
         loadLeaderNotes(currentLeader.id)
-        loadCommunicationSummaries()
         
         // Update button visibility
         checkFollowUpStatus(currentLeader.id)
@@ -5553,7 +5462,6 @@ function populateSearchResultsMobile(results) {
 
         // Refresh notes and follow-up table
         loadLeaderNotes(currentLeader.id)
-        loadCommunicationSummaries()
         
         // Update button visibility
         checkFollowUpStatus(currentLeader.id)
@@ -5574,7 +5482,6 @@ function populateSearchResultsMobile(results) {
 
     document.getElementById('filter-status').addEventListener('change', () => {
       loadCircleLeaders()
-      loadCommunicationSummaries()
     })
 
     // Main action menu functionality
@@ -5748,7 +5655,6 @@ function populateSearchResultsMobile(results) {
     loadCircleLeaders()
 
     // Load communication summaries
-    loadCommunicationSummaries()
 
     // Add sort functionality to table headers
     document.querySelectorAll('.sortable').forEach(header => {
@@ -5808,7 +5714,6 @@ function populateSearchResultsMobile(results) {
         clearStatus()
         setStatus('Seeded successfully!')
         loadCircleLeaders()
-        loadCommunicationSummaries()
       }
     }
 
@@ -5833,23 +5738,9 @@ function populateSearchResultsMobile(results) {
 
       clearStatus()
       setStatus('Database reset and seeded successfully!')
-      loadCommunicationSummaries()
 
       alert('Circle leaders reset successfully!')
     }
-    */
-
-    // Apply summary filter event listener
-    document.getElementById('apply-summary-filter').addEventListener('click', () => {
-      selectedSummaryMonth = parseInt(document.getElementById('summary-month').value)
-      selectedSummaryYear = parseInt(document.getElementById('summary-year').value)
-      loadCommunicationSummaries()
-    })
-
-    // Initialize summary filters on page load
-    initializeSummaryFilters()
-  </script>
-
 
 <!-- Add Logout to main actions dropdown menu -->
 <script>


### PR DESCRIPTION
## Summary
- improve table styling and status labels in `connection_summary.html`
- add sorting support and link names to leaders
- keep connection summary menu link
- remove connection summary section from `index.html`

## Testing
- `node -e "console.log('hello')"`
- `node` supabase test *(fails: TypeError: fetch failed)*
- `npm install puppeteer` *(Chrome failed to launch due to missing libraries)*

------
https://chatgpt.com/codex/tasks/task_e_688309106574832883769e000d8d298c